### PR TITLE
Added a method to cycle through the corner and control points

### DIFF
--- a/src/ofxBezierWarp.cpp
+++ b/src/ofxBezierWarp.cpp
@@ -76,6 +76,35 @@ void ofxBezierWarp::resetAnchors(){
     }
 }
 
+void ofxBezierWarp::nextHandle(){
+    for(int i = 0; i < 4; i++) {
+        selectedSprite[i] = 0;
+        if ((i % 3) == 0) {
+            selectedSprite[i] = 1;
+            mousePosX = corners[i].x;
+            mousePosY = corners[i].y;
+        }
+    }
+
+    for(int i = 0; i < 8; i++) {
+        selectedControlPoint[i] = 0;
+        if (i < 3) {
+            selectedControlPoint[i-1] = 1;
+        } else if (i < 6) {
+            selectedControlPoint[i-2] = 1;
+        } else if (i < 9) {
+            selectedControlPoint[i-3] = 1;
+        } else {
+            selectedControlPoint[i-4] = 1;
+        }
+        mousePosX = anchors[i].x;
+        mousePosY = anchors[i].y;
+    }
+    
+    handleIndex = (handleIndex + 1) % 12;
+}
+
+
 void ofxBezierWarp::update() {
 	if (anchorControl == 0) {
 		// not bezier

--- a/src/ofxBezierWarp.h
+++ b/src/ofxBezierWarp.h
@@ -33,11 +33,14 @@ public:
 		gridRes = 0;
 		prev_gridRes = 0;
 	}
+    
+    int handleIndex = 0;
 	
     void setup(ofFbo* _fbo);
 	void update(); // if you need
 	void draw();
 	
+    void nextHandle();
     void resetAnchors();
 	void save();
 	void load();

--- a/src/ofxBezierWarpManager.cpp
+++ b/src/ofxBezierWarpManager.cpp
@@ -31,6 +31,13 @@ void ofxBezierWarpManager::draw(){
     }
 }
 
+void ofxBezierWarpManager::nextHandle(){
+    // draw bezier
+    for (int i = 0; i < bezierList.size(); i++) {
+        bezierList[i].nextHandle();
+    }
+}
+
 //--------------------------------------------------------------
 void ofxBezierWarpManager::keyPressed(int key){
     for( int i = 0; i < bezierList.size(); i++){

--- a/src/ofxBezierWarpManager.h
+++ b/src/ofxBezierWarpManager.h
@@ -30,6 +30,7 @@ class ofxBezierWarpManager{
     void removeFbo();
     void clear();
     
+    void nextHandle();
     void saveSettings();
     void loadSettings();
     


### PR DESCRIPTION
Hey there, 

I found this addon very useful for setting up a back-projected screen. 
My image needed to be larger than the screen, so large that I could not see the handles to click and drag them . I added in a method that jumps between handles. I hooked it up to a keypress in my code. I'd love to contribute this change back to the addon if you'll have it! Thanks, Sam 